### PR TITLE
Consistently add change addresses to transactions

### DIFF
--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/coin/WalletManager.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/coin/WalletManager.kt
@@ -153,6 +153,15 @@ class WalletManager(
     }
 
     /**
+     * Returns our bitcoin address we use in all multi-sig contracts
+     * we are part of.
+     * @return hex representation of our address
+     */
+    fun protocolAddress(): Address {
+        return kit.wallet().issuedReceiveAddresses[0]
+    }
+
+    /**
      * Returns our bitcoin public key we use in all multi-sig contracts
      * we are part of.
      * @return hex representation of our public key (this is not an address)
@@ -194,12 +203,11 @@ class WalletManager(
         // Add an output with the entrance fee & script.
         transaction.addOutput(entranceFee, script)
 
-        Log.i("Coin", "Coin: your inputs will now be matched to entrance and fees.")
+        Log.i("Coin", "Coin: use SendRequest to add our entranceFee input & change address.")
         val req = SendRequest.forTx(transaction)
+        req.changeAddress = protocolAddress()
         kit.wallet().completeTx(req)
 
-        Log.i("Coin", "Coin: the change address is hard-reset to your protocol key.")
-        req.changeAddress = Address.fromKey(params, protocolECKey(), Script.ScriptType.P2PKH)
 
         return sendTransaction(req.tx)
     }
@@ -245,6 +253,7 @@ class WalletManager(
         Log.i("Coin", "Coin: use SendRequest to add our entranceFee inputs & change address.")
         val req = SendRequest.forTx(newTransaction)
         printTransactionInformation(req.tx)
+        req.changeAddress = protocolAddress()
         kit.wallet().completeTx(req)
 
         return TransactionPackage(

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/coin/WalletManager.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/coin/WalletManager.kt
@@ -208,7 +208,6 @@ class WalletManager(
         req.changeAddress = protocolAddress()
         kit.wallet().completeTx(req)
 
-
         return sendTransaction(req.tx)
     }
 

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/BitcoinFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/BitcoinFragment.kt
@@ -104,13 +104,7 @@ class BitcoinFragment : BaseFragment(R.layout.fragment_bitcoin),
     private fun initClickListeners() {
         button_copy_public_address.setOnClickListener {
             val walletManager = WalletManagerAndroid.getInstance()
-            copyToClipboard(
-                Address.fromKey(
-                    walletManager.params,
-                    walletManager.protocolECKey(),
-                    Script.ScriptType.P2PKH
-                ).toString()
-            )
+            copyToClipboard( walletManager.protocolAddress().toString() )
         }
 
         button_copy_wallet_seed.setOnClickListener {
@@ -156,12 +150,8 @@ class BitcoinFragment : BaseFragment(R.layout.fragment_bitcoin),
         }
         val seed = walletManager.toSeed()
         walletSeed.text = "${seed.seed}, ${seed.creationTime}"
-        yourPublicHex.text = "${walletManager.networkPublicECKeyHex()}"
-        protocolKey.text = Address.fromKey(
-            walletManager.params,
-            walletManager.protocolECKey(),
-            Script.ScriptType.P2PKH
-        ).toString()
+        yourPublicHex.text = walletManager.networkPublicECKeyHex()
+        protocolKey.text = walletManager.protocolAddress().toString()
 
         requireActivity().invalidateOptionsMenu()
     }

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/BitcoinFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/BitcoinFragment.kt
@@ -17,9 +17,7 @@ import nl.tudelft.trustchain.currencyii.coin.BitcoinNetworkOptions
 import nl.tudelft.trustchain.currencyii.coin.WalletManagerAndroid
 import nl.tudelft.trustchain.currencyii.coin.WalletManagerConfiguration
 import nl.tudelft.trustchain.currencyii.ui.BaseFragment
-import org.bitcoinj.core.Address
 import org.bitcoinj.core.NetworkParameters
-import org.bitcoinj.script.Script
 
 /**
  * A simple [Fragment] subclass.
@@ -104,7 +102,7 @@ class BitcoinFragment : BaseFragment(R.layout.fragment_bitcoin),
     private fun initClickListeners() {
         button_copy_public_address.setOnClickListener {
             val walletManager = WalletManagerAndroid.getInstance()
-            copyToClipboard( walletManager.protocolAddress().toString() )
+            copyToClipboard(walletManager.protocolAddress().toString())
         }
 
         button_copy_wallet_seed.setOnClickListener {


### PR DESCRIPTION
Add changes addresses correctly to transactions now. 
Before they were set after the transaction was completed using the bitcoinj library. Now the money should stay on the same address.