### PR TITLE
Explicit proposals

### DIFF
--- a/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
+++ b/app/src/main/java/nl/tudelft/trustchain/app/TrustChainApplication.kt
@@ -89,20 +89,6 @@ class TrustChainApplication : Application() {
                 Log.d("Coin", "onBlockReceived: ${block.blockId} ${block.transaction}")
             }
         })
-
-        trustchain.addListener(CoinCommunity.SIGNATURE_ASK_BLOCK, object : BlockListener {
-            override fun onBlockReceived(block: TrustChainBlock) {
-                Log.d("Coin", "signature request received: ${block.blockId} ${block.transaction}")
-                CoinCommunity.joinAskBlockReceived(block, trustchain.myPeer.publicKey.keyToBin())
-            }
-        })
-
-        trustchain.addListener(CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK, object : BlockListener {
-            override fun onBlockReceived(block: TrustChainBlock) {
-                Log.i("Coin", "block received for signature request: ${block.blockId} ${block.transaction}")
-                CoinCommunity.transferFundsBlockReceived(block, trustchain.myPeer.publicKey.keyToBin())
-            }
-        })
     }
 
     private fun createDiscoveryCommunity(): OverlayConfiguration<DiscoveryCommunity> {

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/CoinCommunity.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/CoinCommunity.kt
@@ -174,6 +174,26 @@ class CoinCommunity : Community() {
     }
 
     /**
+     * Fetch all join and transfer proposals in descending timestamp order.
+     * Speed assumption: each proposal has a unique proposal ID (distinct by unique proposal id,
+     * without taking the unique wallet id into account).
+     */
+    public fun fetchProposalBlocks(): List<TrustChainBlock> {
+        val joinProposals = getTrustChainCommunity().database.getBlocksWithType(SIGNATURE_ASK_BLOCK)
+        val transferProposals = getTrustChainCommunity().database.getBlocksWithType(
+            TRANSFER_FUNDS_ASK_BLOCK
+        )
+        return joinProposals
+            .union(transferProposals)
+            .distinctBy {
+                val data = SWSignatureAskTransactionData(it.transaction).getData()
+                data.SW_UNIQUE_PROPOSAL_ID
+            }.sortedByDescending {
+                it.timestamp
+            }
+    }
+
+    /**
      * Fetch all DAO blocks that contain a signature. These blocks are the response of a signature request.
      * Signatures are fetched from [SIGNATURE_AGREEMENT_BLOCK] type blocks.
      */

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/CoinCommunity.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/CoinCommunity.kt
@@ -3,6 +3,7 @@ package nl.tudelft.trustchain.currencyii
 import nl.tudelft.ipv8.Community
 import nl.tudelft.ipv8.android.IPv8Android
 import nl.tudelft.ipv8.attestation.trustchain.*
+import nl.tudelft.ipv8.util.hexToBytes
 import nl.tudelft.ipv8.util.toHex
 import nl.tudelft.trustchain.currencyii.sharedWallet.*
 import nl.tudelft.trustchain.currencyii.util.DAOCreateHelper
@@ -47,12 +48,12 @@ class CoinCommunity : Community() {
      * 2.1 Send a proposal on the trust chain to join a shared wallet and to collect signatures.
      * The proposal is a serialized bitcoin join transaction.
      * **NOTE** the latest walletBlockData should be given, otherwise the serialized transaction is invalid.
-     * @param walletBlockData - the latest (that you know of) shared wallet block.
+     * @param walletBlock - the latest (that you know of) shared wallet block.
      */
     public fun proposeJoinWallet(
-        walletBlockData: TrustChainTransaction
+        walletBlock: TrustChainBlock
     ): SWSignatureAskTransactionData {
-        return daoJoinHelper.proposeJoinWallet(myPeer, walletBlockData)
+        return daoJoinHelper.proposeJoinWallet(myPeer, walletBlock)
     }
 
     /**
@@ -211,7 +212,7 @@ class CoinCommunity : Community() {
             .union(transferProposals)
             .filter { fetchSignatureRequestReceiver(it) == myPeer.publicKey.keyToBin().toHex() }
             .distinctBy { fetchSignatureRequestProposalId(it) }
-            .sortedByDescending {  it.timestamp }
+            .sortedByDescending { it.timestamp }
     }
 
     /**
@@ -229,14 +230,24 @@ class CoinCommunity : Community() {
             }
     }
 
-    companion object {
-        /**
-         * Given a shared wallet proposal block, calculate the signature and respond with a trust chain block.
-         */
-        fun joinAskBlockReceived(block: TrustChainBlock, myPublicKey: ByteArray) {
-            DAOJoinHelper.joinAskBlockReceived(block, myPublicKey)
-        }
+    /**
+     * Given a shared wallet proposal block, calculate the signature and respond with a trust chain block.
+     */
+    public fun joinAskBlockReceived(
+        block: TrustChainBlock,
+        myPublicKey: ByteArray
+    ) {
+        val latestHash = SWSignatureAskTransactionData(block.transaction).getData()
+            .SW_PREVIOUS_BLOCK_HASH
+        val mostRecentSWBlock = fetchLatestSharedWalletBlock(latestHash.hexToBytes())
+            ?: throw IllegalStateException("Most recent DAO block not found")
+        val oldTransaction = SWJoinBlockTransactionData(mostRecentSWBlock.transaction).getData()
+            .SW_TRANSACTION_SERIALIZED
 
+        DAOJoinHelper.joinAskBlockReceived(oldTransaction, block, myPublicKey)
+    }
+
+    companion object {
         /**
          * Given a shared wallet transfer fund proposal block, calculate the signature and respond with a trust chain block.
          */
@@ -255,18 +266,18 @@ class CoinCommunity : Community() {
         public const val DEFAULT_BITCOIN_MAX_TIMEOUT: Long = 60 * 5
 
         // Block type for join DAO blocks
-        public const val JOIN_BLOCK = "DAO_JOIN"
+        public const val JOIN_BLOCK = "v1DAO_JOIN"
 
         // Block type for transfer funds (from a DAO)
-        public const val TRANSFER_FINAL_BLOCK = "DAO_TRANSFER_FINAL"
+        public const val TRANSFER_FINAL_BLOCK = "v1DAO_TRANSFER_FINAL"
 
         // Block type for basic signature requests
-        public const val SIGNATURE_ASK_BLOCK = "DAO_ASK_SIGNATURE"
+        public const val SIGNATURE_ASK_BLOCK = "v1DAO_ASK_SIGNATURE"
 
         // Block type for transfer funds signature requests
-        public const val TRANSFER_FUNDS_ASK_BLOCK = "DAO_TRANSFER_ASK_SIGNATURE"
+        public const val TRANSFER_FUNDS_ASK_BLOCK = "v1DAO_TRANSFER_ASK_SIGNATURE"
 
         // Block type for responding to a signature request with a (should be valid) signature
-        public const val SIGNATURE_AGREEMENT_BLOCK = "DAO_SIGNATURE_AGREEMENT"
+        public const val SIGNATURE_AGREEMENT_BLOCK = "v1DAO_SIGNATURE_AGREEMENT"
     }
 }

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/sharedWallet/SWSignatureAskTransactionData.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/sharedWallet/SWSignatureAskTransactionData.kt
@@ -9,7 +9,7 @@ data class SWSignatureAskBlockTD(
     var SW_UNIQUE_ID: String,
     var SW_UNIQUE_PROPOSAL_ID: String,
     var SW_TRANSACTION_SERIALIZED: String,
-    var SW_TRANSACTION_SERIALIZED_OLD: String,
+    var SW_PREVIOUS_BLOCK_HASH: String,
     var SW_SIGNATURES_REQUIRED: Int,
     var SW_RECEIVER_PK: String
 )
@@ -24,7 +24,7 @@ open class SWSignatureAskTransactionData(data: JsonObject) : SWBlockTransactionD
     constructor(
         uniqueId: String,
         transactionSerialized: String,
-        oldTransactionSerialized: String,
+        previousBlockHash: String,
         requiredSignatures: Int,
         receiverPk: String,
         uniqueProposalId: String = SWUtil.randomUUID()
@@ -34,7 +34,7 @@ open class SWSignatureAskTransactionData(data: JsonObject) : SWBlockTransactionD
                 uniqueId,
                 uniqueProposalId,
                 transactionSerialized,
-                oldTransactionSerialized,
+                previousBlockHash,
                 requiredSignatures,
                 receiverPk
             )

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/sharedWallet/SWTransferFundsAskTransactionData.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/sharedWallet/SWTransferFundsAskTransactionData.kt
@@ -8,7 +8,7 @@ import nl.tudelft.ipv8.attestation.trustchain.TrustChainTransaction
 data class SWTransferFundsAskBlockTD(
     var SW_UNIQUE_ID: String,
     var SW_UNIQUE_PROPOSAL_ID: String,
-    var SW_TRANSACTION_SERIALIZED_OLD: String,
+    var SW_PREVIOUS_BLOCK_HASH: String,
     var SW_BITCOIN_PKS: List<String>,
     var SW_SIGNATURES_REQUIRED: Int,
     var SW_TRANSFER_FUNDS_AMOUNT: Long,
@@ -25,7 +25,7 @@ class SWTransferFundsAskTransactionData(data: JsonObject) : SWBlockTransactionDa
 
     constructor(
         uniqueId: String,
-        oldTransactionSerialized: String,
+        previousWalletBlockHash: String,
         requiredSignatures: Int,
         satoshiAmount: Long,
         bitcoinPks: List<String>,
@@ -37,7 +37,7 @@ class SWTransferFundsAskTransactionData(data: JsonObject) : SWBlockTransactionDa
             SWTransferFundsAskBlockTD(
                 uniqueId,
                 uniqueProposalId,
-                oldTransactionSerialized,
+                previousWalletBlockHash,
                 bitcoinPks,
                 requiredSignatures,
                 satoshiAmount,

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/JoinNetworkFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/JoinNetworkFragment.kt
@@ -167,7 +167,7 @@ class JoinNetworkFragment() : BaseFragment(R.layout.fragment_join_network) {
         // Add a proposal to trust chain to join a shared wallet
         val proposeBlockData = try {
             getCoinCommunity().proposeJoinWallet(
-                mostRecentSWBlock.transaction
+                mostRecentSWBlock
             ).getData()
         } catch (t: Throwable) {
             Log.i("Coin", "Join wallet proposal failed. ${t.message ?: "No further information"}.")

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -34,8 +34,7 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
                 Log.i("Coin", "${databaseProposals.size} proposals found in database!")
                 updateProposals(databaseProposals)
                 updateProposalListUI()
-                crawlProposals()
-                updateProposalListUI()
+                crawlProposalsAndUpdateIfNewFound()
             }
         }
     }
@@ -80,7 +79,7 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
     /**
      * Crawl all shared wallet blocks of users in the trust chain.
      */
-    private suspend fun crawlProposals() {
+    private suspend fun crawlProposalsAndUpdateIfNewFound() {
         val allUsers = getDemoCommunity().getPeers()
         Log.i("Coin", "Found ${allUsers.size} peers, crawling")
 
@@ -95,7 +94,10 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
                                 it.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK
                         }
                     Log.i("Coin", "Crawl result: ${crawlResult.size} proposals found (from ${peer.address})")
-                    updateProposals(crawlResult)
+                    if (crawlResult.isNotEmpty()) {
+                        updateProposals(crawlResult)
+                        updateProposalListUI()
+                    }
                 }
             } catch (t: Throwable) {
                 val message = t.message ?: "no message"

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -45,12 +45,16 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
             proposal_list_view.setOnItemClickListener { _, _, position, _ ->
                 val block = proposals[position]
                 if (block.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK) {
-                    Log.i("Coin", "Voted yes on transferring funds of: ${block.transaction}")
-                    CoinCommunity.transferFundsBlockReceived(block, myPublicKey)
+                    try {
+                        Log.i("Coin", "Voted yes on transferring funds of: ${block.transaction}")
+                        getCoinCommunity().transferFundsBlockReceived(block, myPublicKey)
+                    } catch (t: Throwable) {
+                        Log.i("Coin", "transfer voting failed: ${t.message ?: "no message"}")
+                    }
                 }
                 if (block.type == CoinCommunity.SIGNATURE_ASK_BLOCK) {
-                    Log.i("Coin", "Voted yes on joining of: ${block.transaction}")
                     try {
+                        Log.i("Coin", "Voted yes on joining of: ${block.transaction}")
                         getCoinCommunity().joinAskBlockReceived(block, myPublicKey)
                     } catch (t: Throwable) {
                         Log.i("Coin", "join voting failed: ${t.message ?: "no message"}")

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -61,15 +61,16 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
      * Update the currently stored proposals. Only new and unique proposals are added.
      */
     private fun updateProposals(newProposals: List<TrustChainBlock>) {
+        val coinCommunity = getCoinCommunity()
         val proposalIds = proposals.map {
-            proposalIdFromBlock(it) ?: "no-id"
+            coinCommunity.fetchSignatureRequestProposalId(it) ?: "no-id"
         }
         val distinctById = newProposals.distinctBy {
-            proposalIdFromBlock(it)
+            coinCommunity.fetchSignatureRequestProposalId(it)
         }
 
         for (proposal in distinctById) {
-            val currentId = proposalIdFromBlock(proposal)
+            val currentId = coinCommunity.fetchSignatureRequestProposalId(proposal)
             if (!proposalIds.contains(currentId)) {
                 proposals.add(proposal)
             }
@@ -104,18 +105,6 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
                 Log.i("Coin", "Crawling failed for: ${peer.address} message: $message")
             }
         }
-    }
-
-    private fun proposalIdFromBlock(block: TrustChainBlock): Any? {
-        if (block.type == CoinCommunity.SIGNATURE_ASK_BLOCK) {
-            return SWSignatureAskTransactionData(block.transaction).getData().SW_UNIQUE_PROPOSAL_ID
-        }
-        if (block.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK) {
-            return SWTransferFundsAskTransactionData(block.transaction).getData()
-                .SW_UNIQUE_PROPOSAL_ID
-        }
-
-        return null
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -6,8 +6,17 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import kotlinx.android.synthetic.main.fragment_my_proposals.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
+import nl.tudelft.trustchain.currencyii.CoinCommunity
 import nl.tudelft.trustchain.currencyii.R
+import nl.tudelft.trustchain.currencyii.sharedWallet.SWSignatureAskTransactionData
+import nl.tudelft.trustchain.currencyii.sharedWallet.SWTransferFundsAskTransactionData
 import nl.tudelft.trustchain.currencyii.ui.BaseFragment
 
 /**
@@ -16,21 +25,99 @@ import nl.tudelft.trustchain.currencyii.ui.BaseFragment
  * create an instance of this fragment.
  */
 class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
+    private var proposals: ArrayList<TrustChainBlock> = ArrayList()
 
-    private fun updateProposalList() {
-        val sharedWalletBlocks = getCoinCommunity().fetchProposalBlocks()
-        Log.i("Coin", "${sharedWalletBlocks.size} proposals found!")
-        val adaptor =
-            ProposalListAdapter(this, sharedWalletBlocks)
-        proposal_list_view.adapter = adaptor
-        proposal_list_view.setOnItemClickListener { _, view, position, id ->
-            Log.i("Coin", "Clicked: $view, $position, $id")
+    private fun fetchProposalsAndUpdateUI() {
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                val databaseProposals = getCoinCommunity().fetchProposalBlocks()
+                Log.i("Coin", "${databaseProposals.size} proposals found in database!")
+                updateProposals(databaseProposals)
+                updateProposalListUI()
+                crawlProposals()
+                updateProposalListUI()
+            }
         }
+    }
+
+    private fun updateProposalListUI() {
+        activity?.runOnUiThread {
+            val adaptor = ProposalListAdapter(this, proposals)
+            proposal_list_view.adapter = adaptor
+            proposal_list_view.setOnItemClickListener { some, view, position, id ->
+                Log.i("Coin", "Clicked: $some, $view, $position, $id")
+            }
+        }
+    }
+
+    /**
+     * Update the currently stored proposals. Only new and unique proposals are added.
+     */
+    private fun updateProposals(newProposals: List<TrustChainBlock>) {
+        val proposalIds = proposals.map {
+            proposalIdFromBlock(it) ?: "no-id"
+        }
+        val distinctById = newProposals.distinctBy {
+            proposalIdFromBlock(it)
+        }
+
+        for (proposal in distinctById) {
+            val currentId = proposalIdFromBlock(proposal)
+            if (!proposalIds.contains(currentId)) {
+                proposals.add(proposal)
+            }
+        }
+    }
+
+    /**
+     * Crawl all shared wallet blocks of users in the trust chain.
+     */
+    private suspend fun crawlProposals() {
+        val allUsers = getDemoCommunity().getPeers()
+        Log.i("Coin", "Found ${allUsers.size} peers, crawling")
+
+        for (peer in allUsers) {
+            try {
+                withTimeout(JoinNetworkFragment.SW_CRAWLING_TIMEOUT_MILLI) {
+                    trustchain.crawlChain(peer)
+                    val crawlResult = trustchain
+                        .getChainByUser(peer.publicKey.keyToBin())
+                        .filter {
+                            it.type == CoinCommunity.SIGNATURE_ASK_BLOCK
+                                || it.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK
+                        }
+                    Log.i("Coin", "Crawl result: ${crawlResult.size} proposals found")
+                    updateProposals(crawlResult)
+                }
+            } catch (t: Throwable) {
+                val message = t.message ?: "no message"
+                Log.i("Coin", "Crawling failed for: ${peer.address} message: $message")
+            }
+        }
+    }
+
+    private fun proposalIdFromBlock(block: TrustChainBlock): Any? {
+        if (block.type == CoinCommunity.SIGNATURE_ASK_BLOCK) {
+            return SWSignatureAskTransactionData(block.transaction).getData().SW_UNIQUE_PROPOSAL_ID
+        }
+        if (block.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK) {
+            return SWTransferFundsAskTransactionData(block.transaction).getData()
+                .SW_UNIQUE_PROPOSAL_ID
+        }
+
+        return null
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        updateProposalList()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        lifecycleScope.launchWhenStarted {
+            fetchProposalsAndUpdateUI()
+        }
     }
 
     override fun onCreateView(

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -63,7 +63,7 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
     private fun updateProposals(newProposals: List<TrustChainBlock>) {
         val coinCommunity = getCoinCommunity()
         val proposalIds = proposals.map {
-            coinCommunity.fetchSignatureRequestProposalId(it) ?: "no-id"
+            coinCommunity.fetchSignatureRequestProposalId(it)
         }
         val distinctById = newProposals.distinctBy {
             coinCommunity.fetchSignatureRequestProposalId(it)

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -44,8 +44,17 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
         activity?.runOnUiThread {
             val adaptor = ProposalListAdapter(this, proposals)
             proposal_list_view.adapter = adaptor
-            proposal_list_view.setOnItemClickListener { some, view, position, id ->
-                Log.i("Coin", "Clicked: $some, $view, $position, $id")
+            proposal_list_view.setOnItemClickListener { _, _, position, _ ->
+                Log.i("Coin", "Clicked: $position")
+                val block = proposals[position]
+                if (block.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK) {
+                    Log.i("Coin", "Voted yes on transferring funds of: ${block.transaction}")
+                    CoinCommunity.transferFundsBlockReceived(block, getTrustChainCommunity().myPeer.publicKey.keyToBin())
+                }
+                if (block.type == CoinCommunity.SIGNATURE_ASK_BLOCK) {
+                    Log.i("Coin", "Voted yes on joining of: ${block.transaction}")
+                    CoinCommunity.joinAskBlockReceived(block, getTrustChainCommunity().myPeer.publicKey.keyToBin())
+                }
             }
         }
     }
@@ -83,10 +92,10 @@ class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
                     val crawlResult = trustchain
                         .getChainByUser(peer.publicKey.keyToBin())
                         .filter {
-                            it.type == CoinCommunity.SIGNATURE_ASK_BLOCK
-                                || it.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK
+                            it.type == CoinCommunity.SIGNATURE_ASK_BLOCK ||
+                                it.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK
                         }
-                    Log.i("Coin", "Crawl result: ${crawlResult.size} proposals found")
+                    Log.i("Coin", "Crawl result: ${crawlResult.size} proposals found (from ${peer.address})")
                     updateProposals(crawlResult)
                 }
             } catch (t: Throwable) {

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/MyProposalsFragment.kt
@@ -1,17 +1,14 @@
 package nl.tudelft.trustchain.currencyii.ui.bitcoin
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_my_proposals.*
 import nl.tudelft.trustchain.currencyii.R
 import nl.tudelft.trustchain.currencyii.ui.BaseFragment
-
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
 
 /**
  * A simple [Fragment] subclass.
@@ -19,6 +16,22 @@ private const val ARG_PARAM2 = "param2"
  * create an instance of this fragment.
  */
 class MyProposalsFragment : BaseFragment(R.layout.fragment_my_proposals) {
+
+    private fun updateProposalList() {
+        val sharedWalletBlocks = getCoinCommunity().fetchProposalBlocks()
+        Log.i("Coin", "${sharedWalletBlocks.size} proposals found!")
+        val adaptor =
+            ProposalListAdapter(this, sharedWalletBlocks)
+        proposal_list_view.adapter = adaptor
+        proposal_list_view.setOnItemClickListener { _, view, position, id ->
+            Log.i("Coin", "Clicked: $view, $position, $id")
+        }
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        updateProposalList()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/ProposalListAdapter.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/ProposalListAdapter.kt
@@ -23,6 +23,7 @@ class ProposalListAdapter(
         val block = items[p0]
         val formatter = SimpleDateFormat("dd-MM-yyyy HH:mm")
 
+        val about = view.findViewById<TextView>(R.id.about_tv)
         val createdAt = view.findViewById<TextView>(R.id.timestamp_tv)
         val doaId = view.findViewById<TextView>(R.id.dao_id_tv)
         val proposalId = view.findViewById<TextView>(R.id.proposal_id_tv)
@@ -30,6 +31,7 @@ class ProposalListAdapter(
 
         if (block.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK) {
             val data = SWTransferFundsAskTransactionData(block.transaction).getData()
+            about.text = "Transfer funds request"
             createdAt.text = formatter.format(block.timestamp)
             doaId.text = data.SW_UNIQUE_ID
             proposalId.text = data.SW_UNIQUE_PROPOSAL_ID
@@ -38,6 +40,7 @@ class ProposalListAdapter(
 
         if (block.type == CoinCommunity.SIGNATURE_ASK_BLOCK) {
             val data = SWSignatureAskTransactionData(block.transaction).getData()
+            about.text = "Join request"
             createdAt.text = formatter.format(block.timestamp)
             doaId.text = data.SW_UNIQUE_ID
             proposalId.text = data.SW_UNIQUE_PROPOSAL_ID

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/ProposalListAdapter.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/ProposalListAdapter.kt
@@ -1,0 +1,61 @@
+package nl.tudelft.trustchain.currencyii.ui.bitcoin
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import android.widget.TextView
+import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
+import nl.tudelft.trustchain.currencyii.CoinCommunity
+import nl.tudelft.trustchain.currencyii.R
+import nl.tudelft.trustchain.currencyii.sharedWallet.SWSignatureAskTransactionData
+import nl.tudelft.trustchain.currencyii.sharedWallet.SWTransferFundsAskTransactionData
+import nl.tudelft.trustchain.currencyii.ui.BaseFragment
+import java.text.SimpleDateFormat
+
+class ProposalListAdapter(
+    private val context: BaseFragment,
+    private val items: List<TrustChainBlock>
+) : BaseAdapter() {
+
+    override fun getView(p0: Int, p1: View?, p2: ViewGroup?): View {
+        val view = context.layoutInflater.inflate(R.layout.proposal_row_data, null, false)
+
+        val block = items[p0]
+        val formatter = SimpleDateFormat("dd-MM-yyyy HH:mm")
+
+        val createdAt = view.findViewById<TextView>(R.id.timestamp_tv)
+        val doaId = view.findViewById<TextView>(R.id.dao_id_tv)
+        val proposalId = view.findViewById<TextView>(R.id.proposal_id_tv)
+        val signaturesRequired = view.findViewById<TextView>(R.id.signatures_required_tv)
+
+        if (block.type == CoinCommunity.TRANSFER_FUNDS_ASK_BLOCK) {
+            val data = SWTransferFundsAskTransactionData(block.transaction).getData()
+            createdAt.text = formatter.format(block.timestamp)
+            doaId.text = data.SW_UNIQUE_ID
+            proposalId.text = data.SW_UNIQUE_PROPOSAL_ID
+            signaturesRequired.text = "${data.SW_SIGNATURES_REQUIRED}"
+        }
+
+        if (block.type == CoinCommunity.SIGNATURE_ASK_BLOCK) {
+            val data = SWSignatureAskTransactionData(block.transaction).getData()
+            createdAt.text = formatter.format(block.timestamp)
+            doaId.text = data.SW_UNIQUE_ID
+            proposalId.text = data.SW_UNIQUE_PROPOSAL_ID
+            signaturesRequired.text = "${data.SW_SIGNATURES_REQUIRED}"
+        }
+
+        return view
+    }
+
+    override fun getItem(p0: Int): Any {
+        return items[p0]
+    }
+
+    override fun getItemId(p0: Int): Long {
+        return p0.toLong()
+    }
+
+    override fun getCount(): Int {
+        return items.size
+    }
+}

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/SharedWalletTransaction.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/ui/bitcoin/SharedWalletTransaction.kt
@@ -76,7 +76,7 @@ class SharedWalletTransaction : BaseFragment(R.layout.fragment_shared_wallet_tra
 
         val transferFundsData = try {
             getCoinCommunity().proposeTransferFunds(
-                walletData,
+                swJoinBlock,
                 bitcoinPublicKey,
                 satoshiTransferAmount
             )

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOJoinHelper.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOJoinHelper.kt
@@ -184,7 +184,11 @@ class DAOJoinHelper {
          * Given a shared wallet proposal block, calculate the signature and send an agreement block.
          * Called by the listener of the [SIGNATURE_ASK_BLOCK] type. Respond with [SIGNATURE_AGREEMENT_BLOCK].
          */
-        fun joinAskBlockReceived(oldTransactionSerialized: String, block: TrustChainBlock, myPublicKey: ByteArray) {
+        fun joinAskBlockReceived(
+            oldTransactionSerialized: String,
+            block: TrustChainBlock,
+            myPublicKey: ByteArray
+        ) {
             val trustchain = TrustChainHelper(IPv8Android.getInstance().getOverlay() ?: return)
 
             val blockData = SWSignatureAskTransactionData(block.transaction).getData()

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOTransferFundsHelper.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOTransferFundsHelper.kt
@@ -37,6 +37,7 @@ class DAOTransferFundsHelper {
         satoshiAmount: Long
     ): SWTransferFundsAskTransactionData {
         val walletData = SWJoinBlockTransactionData(mostRecentWallet.transaction).getData()
+        val walletHash = mostRecentWallet.calculateHash().toHex()
 
         val oldTransactionSerialized = walletData.SW_TRANSACTION_SERIALIZED
         val total = walletData.SW_BITCOIN_PKS.size
@@ -45,7 +46,7 @@ class DAOTransferFundsHelper {
 
         var askSignatureBlockData = SWTransferFundsAskTransactionData(
             walletData.SW_UNIQUE_ID,
-            oldTransactionSerialized,
+            walletHash,
             requiredSignatures,
             satoshiAmount,
             walletData.SW_BITCOIN_PKS,
@@ -60,7 +61,7 @@ class DAOTransferFundsHelper {
             )
             askSignatureBlockData = SWTransferFundsAskTransactionData(
                 walletData.SW_UNIQUE_ID,
-                oldTransactionSerialized,
+                walletHash,
                 requiredSignatures,
                 satoshiAmount,
                 walletData.SW_BITCOIN_PKS,

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOTransferFundsHelper.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOTransferFundsHelper.kt
@@ -32,10 +32,12 @@ class DAOTransferFundsHelper {
      */
     public fun proposeTransferFunds(
         myPeer: Peer,
-        walletData: SWJoinBlockTD,
+        mostRecentWallet: TrustChainBlock,
         receiverAddressSerialized: String,
         satoshiAmount: Long
     ): SWTransferFundsAskTransactionData {
+        val walletData = SWJoinBlockTransactionData(mostRecentWallet.transaction).getData()
+
         val oldTransactionSerialized = walletData.SW_TRANSACTION_SERIALIZED
         val total = walletData.SW_BITCOIN_PKS.size
         val requiredSignatures =
@@ -168,7 +170,11 @@ class DAOTransferFundsHelper {
         /**
          * Given a shared wallet transfer fund proposal block, calculate the signature and send an agreement block.
          */
-        public fun transferFundsBlockReceived(block: TrustChainBlock, myPublicKey: ByteArray) {
+        public fun transferFundsBlockReceived(
+            oldTransactionSerialized: String,
+            block: TrustChainBlock,
+            myPublicKey: ByteArray
+        ) {
             val trustchain = TrustChainHelper(IPv8Android.getInstance().getOverlay() ?: return)
             val walletManager = WalletManagerAndroid.getInstance()
             val blockData = SWTransferFundsAskTransactionData(block.transaction).getData()
@@ -186,7 +192,7 @@ class DAOTransferFundsHelper {
             val satoshiAmount = Coin.valueOf(blockData.SW_TRANSFER_FUNDS_AMOUNT)
             val previousTransaction = Transaction(
                 walletManager.params,
-                blockData.SW_TRANSACTION_SERIALIZED_OLD.hexToBytes()
+                oldTransactionSerialized.hexToBytes()
             )
             val receiverAddress = org.bitcoinj.core.Address.fromString(
                 walletManager.params,

--- a/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOTransferFundsHelper.kt
+++ b/currencyii/src/main/java/nl/tudelft/trustchain/currencyii/util/DAOTransferFundsHelper.kt
@@ -39,7 +39,6 @@ class DAOTransferFundsHelper {
         val walletData = SWJoinBlockTransactionData(mostRecentWallet.transaction).getData()
         val walletHash = mostRecentWallet.calculateHash().toHex()
 
-        val oldTransactionSerialized = walletData.SW_TRANSACTION_SERIALIZED
         val total = walletData.SW_BITCOIN_PKS.size
         val requiredSignatures =
             SWUtil.percentageToIntThreshold(total, walletData.SW_VOTING_THRESHOLD)

--- a/currencyii/src/main/res/layout/proposal_row_data.xml
+++ b/currencyii/src/main/res/layout/proposal_row_data.xml
@@ -27,6 +27,12 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:paddingRight="10px"
+                    android:text="About:" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingRight="10px"
                     android:text="Proposed at:" />
 
                 <TextView
@@ -52,6 +58,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/about_tv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:text="text" />
 
                 <TextView
                     android:id="@+id/timestamp_tv"

--- a/currencyii/src/main/res/layout/proposal_row_data.xml
+++ b/currencyii/src/main/res/layout/proposal_row_data.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingLeft="5dp"
+            android:paddingTop="5dp"
+            android:paddingRight="5dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingRight="10px"
+                    android:text="Proposed at:" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingRight="10px"
+                    android:text="DOA ID:" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingRight="10px"
+                    android:text="Proposal ID:" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingRight="10px"
+                    android:text="Signatures required:" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/timestamp_tv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:text="text" />
+
+                <TextView
+                    android:id="@+id/dao_id_tv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:text="text" />
+
+                <TextView
+                    android:id="@+id/proposal_id_tv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:text="text" />
+
+                <TextView
+                    android:id="@+id/signatures_required_tv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:text="text" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/click_to_join"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:focusable="false"
+            android:text="vote yes"
+            android:textColor="@color/colorAccent" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Added a screen that shows both joining and transfer funds proposals in a single list. A user votes by clicking on one of the proposals.

Fixed a bug that was caused by too large trustchain block transactions. In the transaction data of (transfer funds or join) proposal trustchain blocks, we removed the old serialized transaction. Instead, we store the trustchain blockhash of a shared wallet trustchain block. The old transaction is fetched by retrieving the most recent shared wallet block based on the blockhash in the proposal. Note that shared wallet blocks contain the latest serialized bitcoin transaction related to the wallet.

The UI will be improved in an other PR.